### PR TITLE
Add an example dropdown for specific models.

### DIFF
--- a/fastchat/conversation.py
+++ b/fastchat/conversation.py
@@ -390,7 +390,7 @@ class Conversation:
     def to_gradio_chatbot(self):
         """Convert the conversation to gradio chatbot format."""
         ret = []
-        for i, (role, msg) in enumerate(self.messages[self.offset :]):
+        for role, msg in self.messages[self.offset :]:
             if role == self.roles[0]:
                 if type(msg) is tuple:
                     msg, image = msg
@@ -476,13 +476,11 @@ class Conversation:
             ret = []
         else:
             ret = [{"role": "system", "content": self.system_message}]
-
-        for i, (_, msg) in enumerate(self.messages[self.offset :]):
-            if i % 2 == 0:
-                ret.append({"role": "user", "content": msg})
-            else:
-                if msg is not None:
-                    ret.append({"role": "assistant", "content": msg})
+        for role, msg in self.messages[self.offset :]:
+            ret.append({"role": role, "content": msg})
+        if ret and ret[-1]["role"] == self.roles[1] and ret[-1]["content"] is None:
+            # Remove final empty assistant role added for generation.
+            ret.pop()
         return ret
 
     def to_gemini_api_messages(self):


### PR DESCRIPTION
To add examples for a model: in the model api json file, add the following property to a given model

```
"examples_file": "s3://path/to/example.json"
```

The examples file should be a dict of example names to partial conversations. The conversations should always end right before a user turn is expected. eg.

```
{
  "teacher": [
    ["assistant", "What can I teach you?"]
  ],
  "chef": [
    ["system", "You are a 5 star michelin chef."],
    ["user", "What can you do?"],
    ["assistant", "I can help you with recipes, nutrition, or restaurant recommendations. How can I help?"]
  ]
}
```

I've tested this somewhat manually and things seem to work fine but of course please let me know if you run into issues in actual use.


## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
